### PR TITLE
Set pin mode on DIP switch pins for Sparkfun Pro Micro compatibility

### DIFF
--- a/firmware/gameport-adapter/gameport-adapter.ino
+++ b/firmware/gameport-adapter/gameport-adapter.ino
@@ -49,6 +49,10 @@ static Driver *createDriver(byte sw) {
 
 void setup() {
   // Serial.begin(9600);
+  pinMode(14, INPUT_PULLUP);
+  pinMode(15, INPUT_PULLUP);
+  pinMode(20, INPUT_PULLUP);
+  pinMode(21, INPUT_PULLUP);
   const auto sw1 = DigitalInput<14, true>{}.isLow();
   const auto sw2 = DigitalInput<15, true>{}.isLow();
   const auto sw3 = DigitalInput<20, true>{}.isLow();


### PR DESCRIPTION
This sets the pin mode on pins 14, 15, 20 and 21 to INPUT_PULLUP so the DIP switches work correctly when using a Sparkfun Pro Micro.  I believe it's a good practice to set all the pins you're using to the right pin mode for Arduinos anyway, to avoid these kinds of things.