### PR TITLE
DigitalInput::wait() optimizations

### DIFF
--- a/firmware/gameport-adapter/DigitalPin.h
+++ b/firmware/gameport-adapter/DigitalPin.h
@@ -101,46 +101,31 @@ public:
 
   /// Gets the value of the input.
   bool get() const {
-    return m_input & m_pin.mask;
+    return read();
   }
 
   /// Checks if the input is high.
   bool isHigh() const {
-    return get();
+    return read();
   }
 
   /// Checks if the input is low
   bool isLow() const {
-    return !get();
+    return !read();
   }
 
   /// Waits for an edge with given timeout.
   /// @param[in] edge is the type of edge to wait for
   /// @param[in] timeount is the timeout in microseconds
   uint16_t wait(Edge edge, uint16_t timeout) const {
-    auto last = get();
-    for (; timeout; timeout--) {
-      const auto next = get();
-      if (last == next) {
-        continue;
-      }
-      switch (edge) {
-        case Edge::falling:
-          if (last > next) {
-            return timeout;
-          }
-          break;
-        case Edge::rising:
-          if (last < next) {
-            return timeout;
-          }
-          break;
-        case Edge::any:
-          return timeout;
-      }
-      last = next;
+    if (edge == Edge::falling) {
+      return waitImpl(timeout, [](uint8_t a, uint8_t) {return a;});
     }
-    return 0u;
+    if (edge == Edge::rising) {
+      return waitImpl(timeout, [](uint8_t, uint8_t b) {return b;});
+    }
+    // edge == Edge::rising
+    return waitImpl(timeout, [](uint8_t a, uint8_t b) {return a|b;});
   }
 
   /// Waits for a state with given timeout.
@@ -155,4 +140,23 @@ public:
 private:
   DigitalPin<Id> m_pin;
   volatile typename DigitalPin<Id>::RegType &m_input;
+
+  uint8_t read() const {
+    return m_input & m_pin.mask;
+  }
+
+  template <typename T>
+  uint16_t waitImpl(uint16_t timeout, T compare) const {
+    auto last = read();
+    for (; timeout; timeout--) {
+      const auto next = read();
+      if (last != next) {
+        if (compare(last, next)) {
+          return timeout;
+        }
+        last = next;
+      }
+    }
+    return 0u;
+  }
 };

--- a/firmware/gameport-adapter/gameport-adapter.ino
+++ b/firmware/gameport-adapter/gameport-adapter.ino
@@ -49,7 +49,7 @@ static Joystick *createJoystick(byte sw) {
 static HidJoystick hidJoystick;
 
 void setup() {
-  //Serial.begin(9600);
+  Serial.begin(9600);
   //while(!Serial);
   const auto sw1 = DigitalInput<14, true>{}.isLow();
   const auto sw2 = DigitalInput<15, true>{}.isLow();


### PR DESCRIPTION
Trying to get some higher performance by reducing the time spent in the DigitalInput::wait() function. Hopefully this will provide a little bit more time to read the bits from the data lines in time. Unfortunately even higher optimization would require a complete rewrite of the data reading structures. This is a try to fix the bug but keep the code simple.