### PR TITLE
reset m_errors = 0; on init

### DIFF
--- a/firmware/gameport-adapter/Sidewinder.h
+++ b/firmware/gameport-adapter/Sidewinder.h
@@ -30,6 +30,7 @@ public:
   /// Resets the joystick and tries to detect the model.
   bool init() override {
     log("Sidewinder init...");
+    m_errors = 0;
     m_model = guessModel(readPacket());
     while (m_model == Model::SW_UNKNOWN) {
       // No data. 3d Pro analog mode?


### PR DESCRIPTION
Without this if you have 5 package decode errors after init it immediately calls init again instead of giving a bit of slack.
E.g. 
init
error
error 
error
error
error
init 
error
init
error
init
error
in my opinion should be
init
error
error 
error
error
error
init
error
error 
error
error
error
init
error
error 
error
error
error
