### PR TITLE
Make gitignore Ignore Gerber Folder; BoM Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /kicad/*-cache 
 /kicad/*-cache.lib 
 /kicad/*-bak
+/kicad/gerber/*

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Part    | Count | LCSC #   | Digikey #                | Mouser Electronics # | C
 CONN1   |   1   | C77835   | 609-5371-ND              | 523-L77SDA15SA4CH4F  | DB15 female connector
 R1..R4  |   4   | C172965  | 13-MFR-25FTE52-100KCT-ND | 603-MFR-25FTE52-100K | 100 kOhm resistors
 SW1     |   1   | C15781   | 2449-KG04ET-ND           | 642-DS04             | DIP-4 switch
-U1      |   1   | C2846071 | ED3024-ND                | 575-11044624         | DIP24 Socket (optional)
+U1      |   1   | C72120   | ED3024-ND                | 575-11044624         | DIP24 Socket (optional)
 U1      |   1   | ---      | 1568-1060-ND             | 474-DEV-12640        | Arduino Pro Micro (ATmega32U4 16MHz, 5V)
 
 ## Known issues

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Part    | Count | LCSC #   | Digikey #                | Mouser Electronics # | C
 --------|-------|----------|--------------------------|----------------------|------------------------------------------
 CONN1   |   1   | C77835   | 609-5371-ND              | 523-L77SDA15SA4CH4F  | DB15 female connector
 R1..R4  |   4   | C172965  | 13-MFR-25FTE52-100KCT-ND | 603-MFR-25FTE52-100K | 100 kOhm resistors
-SW1     |   1   | C15781   | 2449-KG04ET-ND           | 642-NDI04H           | DIP-4 switch
+SW1     |   1   | C15781   | 2449-KG04ET-ND           | 642-DS04             | DIP-4 switch
 U1      |   1   | C2846071 | ED3024-ND                | 575-11044624         | DIP24 Socket (optional)
 U1      |   1   | ---      | 1568-1060-ND             | 474-DEV-12640        | Arduino Pro Micro (ATmega32U4 16MHz, 5V)
 

--- a/README.md
+++ b/README.md
@@ -184,13 +184,13 @@ optimization.
 The hardware is super simple. To build an adapter you'll need the PCB from this
 project and following parts:
 
-Part    | Count | LCSC #  | Digikey #                | Comment
---------|-------|---------|--------------------------|------------------------------------------
-CONN1   |   1   | C77835  | 609-5371-ND              | DB15 female connector
-R1..R4  |   4   | C172965 | 13-MFR-25FTE52-100KCT-ND | 100 kOhm resistors
-SW1     |   1   | C15781  | 2449-KG04ET-ND           | DIP-4 switch
-U1      |   1   | C72120  | ED3024-ND                | DIP24 Socket (optional)
-U1      |   1   | ---     | 1568-1060-ND             | Arduino Pro Micro (ATmega32U4 16MHz, 5V)
+Part    | Count | LCSC #   | Digikey #                | Mouser Electronics # | Comment
+--------|-------|----------|--------------------------|----------------------|------------------------------------------
+CONN1   |   1   | C77835   | 609-5371-ND              | 523-L77SDA15SA4CH4F  | DB15 female connector
+R1..R4  |   4   | C172965  | 13-MFR-25FTE52-100KCT-ND | 603-MFR-25FTE52-100K | 100 kOhm resistors
+SW1     |   1   | C15781   | 2449-KG04ET-ND           | 642-NDI04H           | DIP-4 switch
+U1      |   1   | C2846071 | ED3024-ND                | 575-11044624         | DIP24 Socket (optional)
+U1      |   1   | ---      | 1568-1060-ND             | 474-DEV-12640        | Arduino Pro Micro (ATmega32U4 16MHz, 5V)
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -184,13 +184,13 @@ optimization.
 The hardware is super simple. To build an adapter you'll need the PCB from this
 project and following parts:
 
-Part    | Count | LCSC #   | Digikey #                | Mouser Electronics # | Comment
---------|-------|----------|--------------------------|----------------------|------------------------------------------
-CONN1   |   1   | C77835   | 609-5371-ND              | 523-L77SDA15SA4CH4F  | DB15 female connector
-R1..R4  |   4   | C172965  | 13-MFR-25FTE52-100KCT-ND | 603-MFR-25FTE52-100K | 100 kOhm resistors
-SW1     |   1   | C15781   | 2449-KG04ET-ND           | 642-DS04             | DIP-4 switch
-U1      |   1   | C72120   | ED3051-5-ND              | 649-DILB24P-223TLF   | DIP24 Socket (optional)
-U1      |   1   | ---      | 1568-1060-ND             | 474-DEV-12640        | Arduino Pro Micro (ATmega32U4 16MHz, 5V)
+Part    | Count | LCSC #  | Digikey #                | Mouser Electronics # | Comment
+--------|-------|---------|--------------------------|----------------------|------------------------------------------
+CONN1   |   1   | C77835  | 609-5371-ND              | 523-L77SDA15SA4CH4F  | DB15 female connector
+R1..R4  |   4   | C172965 | 13-MFR-25FTE52-100KCT-ND | 603-MFR-25FTE52-100K | 100 kOhm resistors
+SW1     |   1   | C15781  | 2449-KG04ET-ND           | 642-DS04             | DIP-4 switch
+U1      |   1   | C72120  | ED3051-5-ND              | 649-DILB24P-223TLF   | DIP24 Socket (optional)
+U1      |   1   | ---     | 1568-1060-ND             | 474-DEV-12640        | Arduino Pro Micro (ATmega32U4 16MHz, 5V)
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Part    | Count | LCSC #   | Digikey #                | Mouser Electronics # | C
 CONN1   |   1   | C77835   | 609-5371-ND              | 523-L77SDA15SA4CH4F  | DB15 female connector
 R1..R4  |   4   | C172965  | 13-MFR-25FTE52-100KCT-ND | 603-MFR-25FTE52-100K | 100 kOhm resistors
 SW1     |   1   | C15781   | 2449-KG04ET-ND           | 642-DS04             | DIP-4 switch
-U1      |   1   | C72120   | ED3024-ND                | 575-11044624         | DIP24 Socket (optional)
+U1      |   1   | C72120   | ED3051-5-ND              | 649-DILB24P-223TLF   | DIP24 Socket (optional)
 U1      |   1   | ---      | 1568-1060-ND             | 474-DEV-12640        | Arduino Pro Micro (ATmega32U4 16MHz, 5V)
 
 ## Known issues


### PR DESCRIPTION
Just two small things:

1. Adds a new rule to the gitignore to ignore the default folder kicad generated gerber files are saved.
2. Bill of Materials updates in the readme:
    1. Adds Mouser Electronics options
    2. Updates the LCSC option for the DIP24 socket to match the style of socket at Digikey/Mouser.