### PR TITLE
replace function delay() with delayMicroseconds()

### DIFF
--- a/firmware/gameport-adapter/Logitech.h
+++ b/firmware/gameport-adapter/Logitech.h
@@ -63,7 +63,7 @@ public:
     // read too fast. Following delay will ensure, that after the
     // last read at least 5ms passed to ensure, that the joystick
     // cooled down again.
-    delay(5);
+    delayMicroseconds(5000);
 
     const auto packet = readPacket();
 


### PR DESCRIPTION
Replacing the only occurence of delay(5) with delayMicroseconds(5000) saves 72 bytes.
In the corresponding asm file at address 0000031a this replaces the function `<delay>` with a shorter `<delay.constprop.22>` instruction.