### PR TITLE
Added support for daisy-chained sidewinder gamepads

### DIFF
--- a/firmware/gameport-adapter/HidDevice.h
+++ b/firmware/gameport-adapter/HidDevice.h
@@ -22,12 +22,15 @@ public:
 
   explicit HidDevice()
   : PluggableUSBModule(1, 1, epType) {
-    PluggableUSB().plug(this);
   }
 
   void AppendDescriptor(HIDSubDescriptor *node) {
 
     if (rootNode == nullptr) {
+      // Initialization is delayed until AppendDescriptor
+      // is called for the first time. This allows for creating
+      // HidDevice objects and not initializing them.
+      PluggableUSB().plug(this);
       rootNode = node;
     } else {
       auto current = rootNode;
@@ -90,7 +93,7 @@ protected:
       total += res;
     }
 
-    // Reset the protocol on reenumeration. Normally the host should not 
+    // Reset the protocol on reenumeration. Normally the host should not
     // assume the state of the protocol due to the USB specs, but Windows
     // and Linux just assumes its in report mode.
     protocol = HID_REPORT_PROTOCOL;

--- a/firmware/gameport-adapter/Joystick.h
+++ b/firmware/gameport-adapter/Joystick.h
@@ -23,6 +23,10 @@ class Joystick {
 public:
   static const auto MAX_AXES{16u};
 
+  /// For digital joysticks that can daisy chain off
+  /// of the same port.
+  static const auto MAX_JOYSTICKS{2u};
+
   /// Device description.
   ///
   /// This structure is used to generate the HID description
@@ -82,8 +86,22 @@ public:
   /// Gets the State of the Joystick.
   virtual const State &getState() const = 0;
 
+  /// Override this method to add support for daisy chained joysticks.
+  virtual const State &getState(uint8_t joystickIndex) const
+  {
+    return getState();
+  }
+
   /// Gets the Description of the Joystick.
   virtual const Description &getDescription() const = 0;
+
+  /// Returns the number of daisy chained joysticks
+  /// that are connected. Defaults to 1 as most joysticks
+  /// implementations don't have this feature.  
+  virtual uint8_t getJoystickCount() const
+  {
+    return 1;
+  }
 
   Joystick() = default;
   virtual ~Joystick() = default;

--- a/firmware/gameport-adapter/Sidewinder.h
+++ b/firmware/gameport-adapter/Sidewinder.h
@@ -27,29 +27,52 @@
 ///         https://github.com/torvalds/linux/blob/master/drivers/input/joystick/sidewinder.c
 class Sidewinder : public Joystick {
 public:
+
+  /// The maximum number of sidewinder gamepads supported.
+  /// The gamepad supports up to 4, but I don't have 4 to test with.
+  /// So this is capped at 2. If someone has 4, try it out. Bump up the
+  /// 2 to 4 here as well as in Joystick to 4. It might just work.
+  static const auto MAX_GAMEPADS{min(Joystick::MAX_JOYSTICKS, 2)};
+
   /// Resets the joystick and tries to detect the model.
   bool init() override {
     log("Sidewinder init...");
     m_errors = 0;
 
-    m_model = guessModel(readPacket());
+    uint8_t joystickCount;
+    m_model = guessModel(readPacket(), joystickCount);
     while (m_model == Model::SW_UNKNOWN) {
       // No data. 3d Pro analog mode?
       enableDigitalMode();
-      m_model = guessModel(readPacket());
+      m_model = guessModel(readPacket(), m_joystickCount);
     }
-    log("Detected model %d", m_model);
+    m_joystickCount = joystickCount;
+    log("Detected model %d, count %d", m_model, joystickCount);
     return true;
   }
 
   bool update() override {
     const auto packet = readPacket();
-    State state;
-    if (decode(packet, state)) {
-      m_state = state;
+
+    bool firstJoystickOK = false;
+    for (uint8_t i = 0; i < m_joystickCount; ++i)
+    {
+      State state;
+      if (decode(packet, i, state)) {
+        m_state[i] = state;
+
+        // The logic here is if one of the joysticks in the chain randomly
+        // didn't respond or the cable got loose, it is better to update at 
+        // least one of them than to fail out.
+        firstJoystickOK = firstJoystickOK || (i == 0);
+      }
+    }
+    if (firstJoystickOK)
+    {
       m_errors = 0;
       return true;
     }
+
 
     m_errors++;
     log("Packet decoding failed %d time(s)", m_errors);
@@ -60,7 +83,15 @@ public:
   }
 
   const State &getState() const override {
-    return m_state;
+    return m_state[0];    
+  }
+  const State &getState(uint8_t joystickIndex) const override {
+    return m_state[joystickIndex];
+  }
+
+  uint8_t getJoystickCount() const override
+  {
+    return m_joystickCount;
   }
 
   const Description &getDescription() const override;
@@ -94,12 +125,13 @@ private:
   template <Model M>
   struct Decoder {
     static const Description &getDescription();
-    static bool decode(const Packet &packet, State &state);
+    static bool decode(const Packet &packet, uint8_t joystickIndex, State &state);
   };
 
   /// Guesses joystick model from the size of the packet.
-  Model guessModel(const Packet &packet) const {
+  Model guessModel(const Packet &packet, uint8_t & joystickCount) const {
     log("Guessing model by packet size of %d", packet.size);
+    uint8_t gamepadCount = packet.size / 15;
     switch (packet.size) {
       case 15:
         return Model::SW_GAMEPAD;
@@ -118,6 +150,11 @@ private:
       case 64:
         return Model::SW_3D_PRO;
       default:
+        // for daisychained gamepads, the packet will be a multiple of 15
+        if (gamepadCount > 0 && gamepadCount <= MAX_GAMEPADS && (packet.size % 15 == 0)) {
+          joystickCount = gamepadCount;
+          return Model::SW_GAMEPAD;
+        }
         return Model::SW_UNKNOWN;
     }
   }
@@ -137,7 +174,8 @@ private:
   DigitalInput<GamePort<14>::pin, true> m_data2;
   DigitalOutput<GamePort<3>::pin> m_trigger;
   Model m_model{Model::SW_UNKNOWN};
-  State m_state{};
+  State m_state[Joystick::MAX_JOYSTICKS]{};
+  uint8_t m_joystickCount;
   uint8_t m_errors{};
 
   /// Enables digital mode for 3D Pro.
@@ -219,7 +257,7 @@ private:
   }
 
   /// Decodes bit packet into a state.
-  bool decode(const Packet &packet, State &state) const;
+  bool decode(const Packet &packet, uint8_t joystickIndex, State &state) const;
 };
 
 /// Placeholder for Unknown Device
@@ -231,7 +269,7 @@ public:
     return desc;
   }
 
-  static bool decode(const Packet &, State &) {
+  static bool decode(const Packet &, uint8_t, State &) {
     return false;
   }
 };
@@ -245,7 +283,7 @@ public:
     return desc;
   }
 
-  static bool decode(const Packet &packet, State &state) {
+  static bool decode(const Packet &packet, uint8_t joystickIndex, State &state) {
 
     const auto checksum = [&]() {
       byte result = 0u;
@@ -255,19 +293,25 @@ public:
       return result;
     };
 
-    if (packet.size != 15 || checksum() != 0) {
+    uint8_t joystickCount = packet.size / 15;
+    if (joystickCount < (joystickIndex + 1) || 
+        joystickCount > Joystick::MAX_JOYSTICKS || 
+        (packet.size % 15) != 0 || 
+        (joystickIndex == 0 && checksum() != 0)) {
       return false;
     }
 
+    const uint8_t * data = packet.data + (joystickIndex * 15);
+    
     // Bit 0-1: x-axis (10-left, 01-right, 11-middle)
     // Bit 2-3: y-axis (01-up, 10-down, 11-middle)
     // Bit 4-13: 10 buttons
     // Bit 14: checksum
     for (auto i = 0u; i < 10; i++) {
-      state.buttons |= (~packet.data[i + 4] & 1) << i;
+      state.buttons |= (~data[i + 4] & 1) << i;
     }
-    state.axes[0] = map(1 + packet.data[3] - packet.data[2], 0, 2, 0, 1023);
-    state.axes[1] = map(1 + packet.data[0] - packet.data[1], 0, 2, 0, 1023);
+    state.axes[0] = map(1 + data[3] - data[2], 0, 2, 0, 1023);
+    state.axes[1] = map(1 + data[0] - data[1], 0, 2, 0, 1023);
 
     return true;
   }
@@ -282,7 +326,7 @@ public:
     return desc;
   }
 
-  static bool decode(const Packet &packet, State &state) {
+  static bool decode(const Packet &packet, uint8_t joystickIndex, State &state) {
     const auto value = [&]() {
       uint64_t result{0u};
       for (auto i = 0u; i < packet.size; i++) {
@@ -351,7 +395,7 @@ public:
     return desc;
   }
 
-  static bool decode(const Packet &packet, State &state) {
+  static bool decode(const Packet &packet, uint8_t joystickIndex, State &state) {
 
     // The packet can be either in 3bit or in 1bit mode
     if (packet.size != 16 && packet.size != 48) {
@@ -410,9 +454,9 @@ public:
     return desc;
   }
 
-  static bool decode(const Packet &packet, State &state) {
+  static bool decode(const Packet &packet, uint8_t joystickIndex, State &state) {
     // Decode is identical between the Force Feedback Pro and the Precision Pro.
-    return Decoder<Model::SW_PRECISION_PRO>::decode(packet, state);
+    return Decoder<Model::SW_PRECISION_PRO>::decode(packet, joystickIndex, state);
   }
 };
 
@@ -425,7 +469,7 @@ public:
     return desc;
   }
 
-  static bool decode(const Packet &packet, State &state) {
+  static bool decode(const Packet &packet, uint8_t joystickIndex, State &state) {
 
     // The packet can be either in 3bit or in 1bit mode
     if (packet.size != 11 && packet.size != 33) {
@@ -496,19 +540,19 @@ inline const Joystick::Description &Sidewinder::getDescription() const {
   }
 }
 
-inline bool Sidewinder::decode(const Packet &packet, State &state) const {
+inline bool Sidewinder::decode(const Packet &packet, uint8_t joystickIndex, State &state) const {
   switch (m_model) {
     case Model::SW_GAMEPAD:
-      return Decoder<Model::SW_GAMEPAD>::decode(packet, state);
+      return Decoder<Model::SW_GAMEPAD>::decode(packet, joystickIndex, state);
     case Model::SW_3D_PRO:
-      return Decoder<Model::SW_3D_PRO>::decode(packet, state);
+      return Decoder<Model::SW_3D_PRO>::decode(packet, joystickIndex, state);
     case Model::SW_PRECISION_PRO:
-      return Decoder<Model::SW_PRECISION_PRO>::decode(packet, state);
+      return Decoder<Model::SW_PRECISION_PRO>::decode(packet, joystickIndex, state);
     case Model::SW_FORCE_FEEDBACK_PRO:
-      return Decoder<Model::SW_FORCE_FEEDBACK_PRO>::decode(packet, state);
+      return Decoder<Model::SW_FORCE_FEEDBACK_PRO>::decode(packet, joystickIndex, state);
     case Model::SW_FORCE_FEEDBACK_WHEEL:
-      return Decoder<Model::SW_FORCE_FEEDBACK_WHEEL>::decode(packet, state);
+      return Decoder<Model::SW_FORCE_FEEDBACK_WHEEL>::decode(packet, joystickIndex, state);
     default:
-      return Decoder<Model::SW_UNKNOWN>::decode(packet, state);
+      return Decoder<Model::SW_UNKNOWN>::decode(packet, joystickIndex, state);
   }
 }


### PR DESCRIPTION
This is adding support for up to 2 daisy-chained sidewinder gamepads. The code is generic enough that I think it will work with the maximum of 4, but I don't have 4 to test with.

Partially fixes 10. The reason I say partial is that issue 10 is also requesting passthrough. These changes do not address passthrough.