### PR TITLE
Codeswitch for Shift button function

### DIFF
--- a/firmware/gameport-adapter/Sidewinder.h
+++ b/firmware/gameport-adapter/Sidewinder.h
@@ -402,7 +402,7 @@ public:
     state.axes[0] = bits(9, 10);
     state.axes[1] = bits(19, 10);
     state.axes[2] = map(bits(36, 6), 0, 63, 0, 1023);
-    state.axes[3] = map(bits(29, 7), 0, 127, 1023, 0);
+    state.axes[3] = map(bits(29, 7), 0, 127, 0, 1023);
     state.hat = bits(42, 4);
 #ifndef SWPPSHIFT
     state.buttons = ~bits(0, 9);

--- a/firmware/gameport-adapter/Sidewinder.h
+++ b/firmware/gameport-adapter/Sidewinder.h
@@ -424,7 +424,12 @@ template <>
 class Sidewinder::Decoder<Sidewinder::Model::SW_FORCE_FEEDBACK_PRO> {
 public:
   static const Description &getDescription() {
+#ifndef SWPPSHIFT
     static const Description desc{"MS Sidewinder Force Feedback Pro", 4, 9, 1};
+#endif
+#ifdef SWPPSHIFT
+    static const Description desc{"MS Sidewinder Force Feedback Pro", 4, 16, 1};
+#endif
     return desc;
   }
 


### PR DESCRIPTION
I added a codeswitch to allow using the shift button as originally intended. If the code switch is activated, a Sidewinder Precision Pro is registered as a 16 button joystick, where the lower 8 buttons are normally used, and the upper 8 buttons are used when the shift button at the joystick base is pressed. This is how the shift button on the joystick was marketed, but in no situation has this ever worked for me like that in any game, even back when it was new.

I set the switch to off by default. I think things like this shouldn't be handled in code switches, but instead it should be controlled by settings saved in the Arduino's EPROM. I could think of a number of nifty settings that I would like to give the users as options, if we had more than the DIP switch for configurability.

Previously, I had inverted the throttle axis, but I have since learned that higher values equating to less thrust is apparently the norm, so I have reversed this.