### PR TITLE
Add support for Logitech WingMan Gamepad

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Logitech WingMan Extreme     | 6       | 3     | 1    | 1001  | ADI        |
 Logitech CyberMan 2          | 8       | 6     | 0    | 1001  | ADI        |
 Logitech WingMan Interceptor | 9       | 3     | 3    | 1001  | ADI        | 2 hats are mapped as 4 axes
 Logitech ThunderPad Digital  | 8       | 2     | 0    | 1001  | ADI        | Directional buttons mapped as 2 axes
+Logitech WingMan Gamepad     | 11      | 2     | 0    | 1001  | ADI        | Directional buttons mapped as 2 axes
 Logitech WingMan Light       | 2       | 2     | 0    | 0000  | Analogue   |
 
 *Remarks:*
@@ -128,6 +129,7 @@ so far:
 * Logitech WingMan Interceptor
 * Logitech WingMan Light
 * Logitech ThunderPad Digital
+* Logitech WingMan Gamepad
 * Medion Joypad MD9823 (analog, 4-axes, 4-buttons)
 * QuickShot QS-123E "Warrior 5" (analog)
 * Quickshot QS-146 "Intruder 5" (analog)

--- a/firmware/gameport-adapter/Logitech.h
+++ b/firmware/gameport-adapter/Logitech.h
@@ -44,6 +44,12 @@ public:
       m_description.numButtons = 8;
       m_description.hasHat = 0;
     }
+    // If the device is a Logitech WingMan Gamepad, manually redefine the gamepad layout to 2 axes and 11 buttons
+    else if(m_metaData.deviceID == DEVICE_WINGMAN_GAMEPAD){
+      m_description.numAxes = 2;
+      m_description.numButtons = 11;
+      m_description.hasHat = 0;
+    }
 
     // Initialize axes centers
     uint8_t axis = 0u;
@@ -138,6 +144,16 @@ public:
 
       state.buttons &= 0xFF0F;
       state.buttons |= (state.buttons & 0x0F00) >> 4;
+    }
+    // If the device is a Logitech WingMan Gamepad, manually remap up, down, left and right buttons to X and Y axes
+    else if(m_metaData.deviceID == DEVICE_WINGMAN_GAMEPAD){
+      const auto value = getBits(packet, 8, 4);
+      static constexpr uint16_t dx[] = { 511, 0, 511, 0, 1023, 511, 1023, 511, 511, 0, 511, 0, 1023, 511, 1023, 511 };
+      static constexpr uint16_t dy[] = { 511, 511, 1023, 1023, 511, 511, 1023, 1023, 0, 0, 511, 511, 0, 0, 511, 511 };
+      state.axes[0] = dx[value]; 
+      state.axes[1] = dy[value];
+
+      state.buttons >>= 4;
     }
 
     m_state = state;


### PR DESCRIPTION
The same changes made recently for the Logitech ThunderPad Digital work for the Logitech WingMan Gamepad, but another custom mapping is required to remap the directional buttons as 2 axes.